### PR TITLE
Acessibilidade e erros no input

### DIFF
--- a/src/components/FormContact/index.tsx
+++ b/src/components/FormContact/index.tsx
@@ -45,22 +45,11 @@ export const FormContact = () => {
             name="company"
             label="Nome da empresa"
             placeholder="digite o nome da empresa"
-            error={useFormMethods.formState.errors?.company}
           />
 
-          <Input
-            name="email"
-            label="Email"
-            placeholder="contato@email.com"
-            error={useFormMethods.formState.errors?.email}
-          />
+          <Input name="email" label="Email" placeholder="contato@email.com" />
 
-          <Input
-            name="phone"
-            label="Telefone"
-            placeholder="__ ____________"
-            error={useFormMethods.formState.errors?.phone}
-          />
+          <Input name="phone" label="Telefone" placeholder="__ ____________" />
 
           <Input
             name="employees"

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -5,24 +5,29 @@ import styles from './styles.module.scss'
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string
-  error?: {
-    message: string
-  }
 }
 
-export const Input = ({ name, label, error, ...rest }: InputProps) => {
-  const { register } = useFormContext()
+export const Input = ({ name, label, ...rest }: InputProps) => {
+  const {
+    register,
+    formState: { errors }
+  } = useFormContext()
+
+  const error = errors[name]
+  const isError = !!error
 
   return (
     <div className={styles.container}>
-      <label htmlFor="">{label}</label>
+      <label htmlFor={name}>{label}</label>
       <input
-        className={error?.message ? styles.error : ''}
+        className={isError ? styles.error : ''}
+        aria-invalid={isError}
         type="text"
+        id={name}
         {...rest}
         {...register(name)}
       />
-      {!!error?.message && <span>{error.message}</span>}
+      {isError && <span role="alert">{error.message}</span>}
     </div>
   )
 }


### PR DESCRIPTION
Essa PR adiciona:

- Movendo responsabilidade do erro para dentro do componente `Input`. (igual como você estava tentando fazer na live)
- Melhorando acessibilidade do input ao mostrar erro e conectando `label` ao `input`.